### PR TITLE
Fix pre-commit build error

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: docformatter-venv
+  name: docformatter-venv
+  description: Formats docstrings to follow PEP 257
+  entry: docformatter
+  language: python
+  language_version: python3
+  files: \.py$
+  args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]


### PR DESCRIPTION
# Code Pull Requests

-   **a clear explanation of what your code does**
    This PR resolves the `InvalidManifestError` encountered during `pre-commit.ci` builds. The error was caused by an unsupported `language` type (`python_venv`) specified for the `docformatter-venv` hook in `.pre-commit-hooks.yaml`. This change updates the `language` to the correct and supported `python` type, ensuring pre-commit checks pass successfully.

-   **if applicable, a reference to an issue**
    Addresses the pre-commit.ci build failure observed in PR #4052.

-   **a reproducible test for your PR (code, config and data sample)**
    To verify this fix:
    1.  Ensure `pre-commit` is installed (`pip install pre-commit`).
    2.  Run `pre-commit install` in the repository root.
    3.  Run `pre-commit run --all-files`.
    Expected outcome: The `docformatter-venv` hook should execute without `InvalidManifestError`. The `pre-commit.ci` check on this PR should also pass.